### PR TITLE
Load WireMock URL from .env and Jenkins environment

### DIFF
--- a/src/test/java/apitests/config/ApiMockConfig.java
+++ b/src/test/java/apitests/config/ApiMockConfig.java
@@ -1,11 +1,21 @@
 package apitests.config;
 
+import io.github.cdimascio.dotenv.Dotenv;
+
 public class ApiMockConfig {
 
     private final String mockUrl;
 
     public ApiMockConfig() {
-        this.mockUrl = "http://10.0.0.15:8080"; // WireMock address
+        Dotenv dotenv = Dotenv.configure()
+                .ignoreIfMissing()
+                .load();
+
+        this.mockUrl = dotenv.get("WIREMOCK_URL");
+
+        if (this.mockUrl == null || this.mockUrl.isBlank()) {
+            throw new IllegalStateException("WIREMOCK_URL is not configured");
+        }
     }
 
     public String getMockUrl() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test environment configuration by reading the mock service URL from an environment variable instead of relying on a fixed address.
  * Added a clear failure when the mock URL is missing or empty, making setup issues easier to catch early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->